### PR TITLE
Feature/add structured metadata

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,8 +12,12 @@ _Avoid_: job, dataset, collection
 A single item within a **Batch** — an `s3_uri` paired with an optional `size_bytes`. Passed to `FileFetcher.fetch()` so routing decisions (e.g. size threshold) can be made before any I/O.
 _Avoid_: row, record, file
 
+**Facility**:
+The second path segment of the S3 key under `IMOS/` (for example, `ANMN` from `IMOS/ANMN/NSW/file.nc`). This is the canonical domain term for top-level IMOS grouping.
+_Avoid_: collection (except where required by legacy schema/field names)
+
 **Structured Metadata**:
-A fixed-schema set of fields extracted from a NetCDF file — including spatial extent, temporal range, CRS, file format, `collection`, and `s3_uri`. Stored as a Polars DataFrame and persisted to an S3 Table (Apache Iceberg). `collection` is the second path segment of the S3 key (e.g. `ANMN` from `IMOS/ANMN/NSW/file.nc`), populated by the **MetadataExtractor**. The current extractor derives extent from coordinate arrays; a future v2 extractor will use ACDD global attributes where available (see ADR-0005).
+A fixed-schema set of fields extracted from a NetCDF file — including spatial extent, temporal range, CRS, file format, facility grouping, and `s3_uri`. Stored as a Polars DataFrame and persisted to an S3 Table (Apache Iceberg). Current code still stores facility grouping in legacy field name `collection`, populated by the **MetadataExtractor** from the second path segment. The current extractor derives extent from coordinate arrays; a future v2 extractor will use ACDD global attributes where available (see ADR-0005).
 _Avoid_: metadata (without qualifier)
 
 **Unstructured Metadata**:
@@ -74,11 +78,11 @@ A pluggable component that, given an **XarrayHandle**, extracts both Structured 
 _Avoid_: parser, reader
 
 **StructuredSink**:
-A pluggable component that prepares and persists a Structured Metadata DataFrame to a target store. All implementations expose `provision()` — called once by the **Orchestrator** before Batches are dispatched — and `write()` for each Batch. The production implementation (`StructuredS3TableSink`) writes to an S3 Table (Apache Iceberg) via PyIceberg, partitioned by `collection` then year (from `time_min`; null `time_min` goes to the null partition bucket); appends on each write and retries on OCC conflicts. The local implementation (`StructuredParquetSink`) creates the output directory on `provision()` and writes a Parquet file on each `write()`.
+A pluggable component that prepares and persists a Structured Metadata DataFrame to a target store. All implementations expose `provision()` — called once by the **Orchestrator** before Batches are dispatched — and `write()` for each Batch. The production implementation (`StructuredS3TableSink`) writes to an S3 Table (Apache Iceberg) via PyIceberg, partitioned by legacy field `collection` (domain: **Facility**) then year (from `time_min`; null `time_min` goes to the null partition bucket); appends on each write and retries on OCC conflicts. The local implementation (`StructuredParquetSink`) creates the output directory on `provision()` and writes a Parquet file on each `write()`.
 _Avoid_: writer, exporter
 
 **UnstructuredSink**:
-A pluggable component that prepares and persists Unstructured Metadata dicts (keyed by `s3_uri`) to a final destination store. Receives `dict[str, dict]` — callers resolve `UnstructuredMetadata.load()` before passing. All implementations expose `provision()` and `write()`. The production implementation (`UnstructuredS3TableSink`) writes to an S3 Table (Apache Iceberg) via PyIceberg with schema `(s3_uri STRING, collection STRING, metadata STRING)` where `collection` is derived from the `s3_uri` key at write time and `metadata` is JSON-encoded.
+A pluggable component that prepares and persists Unstructured Metadata dicts (keyed by `s3_uri`) to a final destination store. Receives `dict[str, dict]` — callers resolve `UnstructuredMetadata.load()` before passing. All implementations expose `provision()` and `write()`. The production implementation (`UnstructuredS3TableSink`) writes to an S3 Table (Apache Iceberg) via PyIceberg with schema `(s3_uri STRING, collection STRING, metadata STRING)` where legacy column `collection` stores **Facility** derived from `s3_uri`, and `metadata` is JSON-encoded.
 _Avoid_: writer, exporter
 
 ## Constraints
@@ -120,4 +124,5 @@ _Avoid_: build pipeline, validation pipeline
 ## Flagged ambiguities
 
 - "metadata" (unqualified) was used to mean both **Structured Metadata** and **Unstructured Metadata** — resolved: always qualify the term.
+- "collection" and "facility" were both used for the second S3 path segment — resolved: canonical domain term is **Facility**; keep `collection` only for backward-compatible field/schema names.
 - "file format" was initially derived from xarray private internals (`_file_obj._ds.file_format`) — resolved: always read from magic bytes via `XarrayHandle.file_format`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -88,6 +88,7 @@ _Avoid_: writer, exporter
 - The caller is responsible for ensuring no `s3_uri` appears more than once across pipeline runs
 - diskcache is keyed by `s3_uri`
 - The `StructuredSink` enforces the Structured Metadata schema on write
+- `StructuredMetadata` dataclass is schema source-of-truth for Polars, PyArrow, and Iceberg representations
 - **File Format** is determined from magic bytes (first 8 bytes of the file), not from xarray internals — avoids coupling to private xarray/netCDF4 attributes
 - NetCDF4/HDF5 files require multiple block fetches to traverse the HDF5 btree even for metadata-only reads; this makes `S3XarrayHandle` slower for large NetCDF4 files than for NetCDF3
 - **Three-layer concurrency model**: peak resource usage is `batch_workers × transform_threads × s5cmd_workers`. On Fargate each worker runs in an isolated container so all three can be maximised independently. For local runs all three layers share the same machine and must be capped together to avoid memory exhaustion and CPU saturation.

--- a/analysis/structured_metadata/v1.ipynb
+++ b/analysis/structured_metadata/v1.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "77751b75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data_index.iceberg_config import S3TablesCatalogConfig, IcebergTableConfig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f40ca1d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Sink config ---\n",
+    "data_index_catalog_config = S3TablesCatalogConfig(\n",
+    "    region=\"ap-southeast-2\",\n",
+    "    arn=\"arn:aws:s3tables:ap-southeast-2:704910415367:bucket/data-index\",\n",
+    ")\n",
+    "\n",
+    "structured_metadata_table_config = IcebergTableConfig(\n",
+    "    catalog_config=data_index_catalog_config,\n",
+    "    namespace=\"data_index\",\n",
+    "    table_name=f\"structured_metadata_v1\",\n",
+    ")\n",
+    "\n",
+    "unstructured_metadata_table_config = IcebergTableConfig(\n",
+    "    catalog_config=data_index_catalog_config,\n",
+    "    namespace=\"data_index\",\n",
+    "    table_name=\"unstructured_metadata\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f17e5c96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_index_catalog_config."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "data-index (3.12.11)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/handoff/2026-06-02-local-subset-metadata-analysis.md
+++ b/docs/handoff/2026-06-02-local-subset-metadata-analysis.md
@@ -1,0 +1,74 @@
+# Local subset metadata analysis handoff
+
+## Scope for next session
+
+Design + implement analysis for outputs of:
+
+- `src/data_index/defaults/local_subset.py`
+- `src/data_index/metadata_extractor/attribute_netcdf_extractor.py`
+
+User asked for handoff focused on continuing this analysis work.
+
+## What is already resolved
+
+1. Canonical term is **Facility** (not collection) for second S3 path segment (`IMOS/<facility>/...`).
+2. `collection` remains legacy field/schema name where already present in code/storage.
+3. Analysis metrics to deliver:
+   - Facility extraction success %
+   - Structured per-field success %
+   - Unstructured mapping correctness diagnostics
+4. Because current outputs only persist succeeded rows, extraction success % must be **estimated** (no pipeline code change approved).
+
+## Decisions captured in repository docs
+
+- Updated glossary + ambiguity resolution in:
+  - `CONTEXT.md`
+
+Key glossary decision: **Facility** is canonical domain term; `collection` is legacy alias.
+
+## Agreed analysis design
+
+1. **Facility extraction success % (estimator)**
+   - Denominator per facility: `min(subset_per_facility, inventory_count_facility)` where `subset_per_facility = 10_000`, derived from inventory parquet under `.extract/s3_metadata` (same sampling basis as `LiveS3InventorySourceFacilitySubset`).
+   - Numerator per facility: distinct `s3_uri` count in successful outputs.
+   - Success % = numerator / denominator.
+
+2. **Structured per-field success**
+   - From `structured_metadata.parquet`.
+   - Produce global + per-facility `% non-null` for each structured field.
+
+3. **Unstructured mapping correctness**
+   - Compare `attributes_map` in `AttributeNetCDFExtractor` against keys in unstructured `global_attrs`.
+   - Produce global + per-facility metrics per mapped field:
+     - exact key-presence %
+     - populated-structured %
+     - cast-fail proxy % for numeric fields (`lat/lon`): source key present but structured value null
+     - case-mismatch signals (`lower(key)` matches only)
+     - fuzzy key suggestions (normalized + score >= 90 using `thefuzz`/rapidfuzz)
+
+4. **Flagging/reporting**
+   - Include raw metrics + threshold-based flags + fuzzy suggestions together.
+   - Threshold rule approved: flag where `key_presence >= 20%` and `populated_structured <= 5%`.
+
+## Constraints and user choices
+
+- User explicitly rejected pipeline code change to persist status ledger.
+- User explicitly wants both threshold flags and raw outputs.
+- User approved fuzzy matching suggestions for possible key mapping fixes.
+
+## Suggested next concrete steps
+
+1. Create analysis artifact (single script or notebook) that reads:
+   - `.extract/s3_metadata/**/*.parquet` (inventory basis)
+   - local subset outputs (`structured_metadata.parquet`, `unstructured_metadata.parquet`)
+2. Implement three output tables/reports:
+   - facility success estimator table
+   - structured per-field coverage (global + facility)
+   - mapping mismatch report (exact/case/fuzzy + cast-fail proxy)
+3. Validate with small sample first, then full local subset output.
+
+## Suggested skills for next session
+
+- `prototype` (recommended): quickly build runnable analysis script/notebook variations and compare output shape.
+- `diagnose`: if mismatches or metric anomalies appear during implementation.
+- `grill-with-docs`: if terminology or glossary decisions need further tightening while coding.

--- a/docs/handoff/2026-06-02-structured-metadata-schema-feedback.md
+++ b/docs/handoff/2026-06-02-structured-metadata-schema-feedback.md
@@ -1,0 +1,64 @@
+# Handoff: structured metadata schema feedback
+
+## Session goal
+Work through stakeholder feedback on `src/data_index/structured_metadata.py` using grilling flow before implementation.
+
+## What happened
+- Invoked `grill-with-docs`, then switched to `caveman` mode per user request.
+- Explored:
+  - `src/data_index/structured_metadata.py`
+  - `src/data_index/metadata_extractor/attribute_netcdf_extractor.py`
+  - `src/data_index/metadata_extractor/netcdf_extractor.py`
+  - `src/data_index/structured_sink/s3_table_sink.py`
+  - `src/data_index/local_subset_metadata_analysis.py`
+  - `tests/test_netcdf_extractor.py`
+  - `CONTEXT.md`
+- No code changes made in this session.
+
+## Decisions confirmed with user
+1. **Key discrepancy handling (broader requirement):**
+   - Adopt generic attribute alias resolver.
+   - Strategy: per-field ordered aliases + normalized fallback (`lower`, strip `_`/`-`), first exact alias wins.
+2. **Canonical extractor path:**
+   - `AttributeNetCDFExtractor` is canonical moving forward.
+3. **`file_version_quality_control`:**
+   - Drop from structured schema.
+4. **`metadata_uuid` vs `collection`:**
+   - Keep both for now; do not merge/remove yet.
+   - User flagged uncertainty due to high null rate for `metadata_uuid`.
+5. **New scalar fields:**
+   - Add `feature_type` with alias fallback (`featureType`, `feature_type`).
+   - Add `instrument_serial_number` with alias fallback (`instrument_serial_number`, `instrumentSerialNumber`).
+6. **New list fields:**
+   - Add `dimensions`, `variables`, `standard_names`.
+   - Semantics chosen:
+     - `dimensions`: sorted unique `ds.dims` names
+     - `variables`: sorted `ds.data_vars` names (exclude coords)
+     - `standard_names`: sorted unique `standard_name` values across `ds.data_vars` + `ds.coords`, null/empty dropped
+   - Null policy: use `None` when no values.
+   - Storage type: native list types (not JSON strings).
+7. **Rollout preference:**
+   - User selected full-scope atomic change when implementation begins.
+
+## Important codebase findings
+- `StructuredMetadata` is schema source-of-truth for Polars/PyArrow/PyIceberg.
+- `StructuredS3TableSink.provision()` calls schema evolution via `union_by_name`, so additive columns evolve table schema.
+- `NetCDFExtractor` and `AttributeNetCDFExtractor` both exist; defaults/local wiring currently points to `AttributeNetCDFExtractor`.
+
+## Next session likely tasks
+1. Implement agreed schema changes in `StructuredMetadata`.
+2. Extend type maps to support list[str] in Polars/PyArrow/PyIceberg schema generation.
+3. Implement generic alias resolver + new field extraction in `AttributeNetCDFExtractor`.
+4. Remove structured extraction of `file_version_quality_control`.
+5. Update mirrored mapping in `local_subset_metadata_analysis.py`.
+6. Update/add tests for:
+   - alias resolution behavior
+   - new scalar/list fields extraction semantics
+   - schema generation for list fields
+   - removed `file_version_quality_control` expectations
+7. Run repo tests (`uv run pytest tests/ -v`) and adjust failures.
+
+## Suggested skills for next session
+- `tdd` (recommended): drive schema/extractor/test updates safely.
+- `diagnose`: if list-type schema plumbing fails in Iceberg/PyArrow integration.
+- `grill-with-docs`: only if new stakeholder ambiguity appears during implementation.

--- a/docs/managing-s3-tables.md
+++ b/docs/managing-s3-tables.md
@@ -1,0 +1,18 @@
+## Deleting Tables
+https://docs.aws.amazon.com/cli/latest/reference/s3tables/delete-table.html
+
+```bash
+aws s3tables delete-table\
+--region ap-southeast-2 \
+--table-bucket-arn <value> \
+--namespace <value> \
+--name <value> 
+```
+
+## Deleting Table Buckets
+
+```bash
+aws s3tables delete-table-bucket \
+--region ap-southeast-2 \
+--table-bucket-arn <value>
+```

--- a/docs/managing-s3-tables.md
+++ b/docs/managing-s3-tables.md
@@ -2,7 +2,7 @@
 https://docs.aws.amazon.com/cli/latest/reference/s3tables/delete-table.html
 
 ```bash
-aws s3tables delete-table\
+aws s3tables delete-table \
 --region ap-southeast-2 \
 --table-bucket-arn <value> \
 --namespace <value> \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,9 @@ dev = [
 ]
 analysis = [
     "altair>=5",
+    "genson>=1.3.0",
     "ipykernel>=6",
     "jupyterlab>=4",
+    "natsort>=8.4.0",
     "rich>=13",
 ]

--- a/src/data_index/defaults/local.py
+++ b/src/data_index/defaults/local.py
@@ -40,80 +40,79 @@ TRANSFORM_WORKERS = (
 )
 
 # --- Live Inventory Source config
-_s3_metadata_catalog_config = S3TablesCatalogConfig(
+s3_metadata_catalog_config = S3TablesCatalogConfig(
     region=REGION,
     arn="arn:aws:s3tables:ap-southeast-2:104044260116:bucket/aws-s3",
 )
 
-_inventory_table_config = IcebergTableConfig(
-    catalog_config=_s3_metadata_catalog_config,
+inventory_table_config = IcebergTableConfig(
+    catalog_config=s3_metadata_catalog_config,
     namespace="b_imos-data",
     table_name="inventory",
 )
 
-_inventory_table_scan_config = IcebergTableScanConfig(
+inventory_table_scan_config = IcebergTableScanConfig(
     row_filter="key LIKE 'IMOS/%'",
 )
 
-_live_inventory_source = LiveS3InventorySource(
-    table_config=_inventory_table_config,
-    table_scan_config=_inventory_table_scan_config,
+live_inventory_source = LiveS3InventorySource(
+    table_config=inventory_table_config,
+    table_scan_config=inventory_table_scan_config,
     path=pathlib.Path(".extract/s3_metadata"),
     skip_if_exists=True,
 )
 
 # --- Partitioner config ---
-_greedy_partitioner = GreedyBatchPartitioner(
+partitioner = GreedyBatchPartitioner(
     max_files=BATCH_SIZE,
     max_bytes=50 * 1024**3,
 )
 
 # --- File fetcher ---
-_file_fetcher = S5CMDFetcher(num_workers=S5CMD_WORKERS, anon=True)
+fetcher = S5CMDFetcher(num_workers=S5CMD_WORKERS, anon=True)
 
 # --- Metadata extractor ---
-_attribute_netcdf_extractor = AttributeNetCDFExtractor()
+extractor = AttributeNetCDFExtractor()
 
 # --- Sink config ---
-_data_index_catalog_config = S3TablesCatalogConfig(
+data_index_catalog_config = S3TablesCatalogConfig(
     region=REGION,
     arn="arn:aws:s3tables:ap-southeast-2:704910415367:bucket/data-index",
 )
 
-_structured_metadata_table_config = IcebergTableConfig(
-    catalog_config=_data_index_catalog_config,
+structured_metadata_table_config = IcebergTableConfig(
+    catalog_config=data_index_catalog_config,
     namespace="data_index",
     table_name="structured_metadata",
 )
 
-_structured_s3_table_sink = StructuredS3TableSink(
-    iceberg_table_config=_structured_metadata_table_config,
+structured_sink = StructuredS3TableSink(
+    iceberg_table_config=structured_metadata_table_config,
 )
 
-_unstructured_metadata_table_config = IcebergTableConfig(
-    catalog_config=_data_index_catalog_config,
+unstructured_metadata_table_config = IcebergTableConfig(
+    catalog_config=data_index_catalog_config,
     namespace="data_index",
     table_name="unstructured_metadata",
 )
 
-_unstructured_s3_table_sink = UnstructuredS3TableSink(
-    iceberg_table_config=_unstructured_metadata_table_config,
+unstructured_sink = UnstructuredS3TableSink(
+    iceberg_table_config=unstructured_metadata_table_config,
 )
 
 
 @prefect.flow
 def run_index_local(
     inventory_source: LiveS3InventorySource
-    | ParquetInventorySource = _live_inventory_source,
-    partitioner: GreedyBatchPartitioner = _greedy_partitioner,
-    fetcher: S3Fetcher | S5CMDFetcher | ThresholdFileFetcher = _file_fetcher,
+    | ParquetInventorySource = live_inventory_source,
+    partitioner: GreedyBatchPartitioner = partitioner,
+    fetcher: S3Fetcher | S5CMDFetcher | ThresholdFileFetcher = fetcher,
     extractor: NetCDFExtractor
     | UnstructuedNetCDFExtractor
-    | AttributeNetCDFExtractor = _attribute_netcdf_extractor,
-    structured_sink: StructuredParquetSink
-    | StructuredS3TableSink = _structured_s3_table_sink,
+    | AttributeNetCDFExtractor = extractor,
+    structured_sink: StructuredParquetSink | StructuredS3TableSink = structured_sink,
     unstructured_sink: UnstructuredParquetSink
-    | UnstructuredS3TableSink = _unstructured_s3_table_sink,
+    | UnstructuredS3TableSink = unstructured_sink,
     metadata_factory: InMemoryUnstructuredMetadata
     | DiskCachedUnstructuredMetadata
     | None = None,

--- a/src/data_index/defaults/local.py
+++ b/src/data_index/defaults/local.py
@@ -11,7 +11,11 @@ from data_index.iceberg_config import (
     S3TablesCatalogConfig,
 )
 from data_index.inventory_source import LiveS3InventorySource, ParquetInventorySource
-from data_index.metadata_extractor import NetCDFExtractor, UnstructuedNetCDFExtractor
+from data_index.metadata_extractor import (
+    AttributeNetCDFExtractor,
+    NetCDFExtractor,
+    UnstructuedNetCDFExtractor,
+)
 from data_index.structured_sink import StructuredParquetSink, StructuredS3TableSink
 from data_index.unstructured_metadata import (
     DiskCachedUnstructuredMetadata,
@@ -29,10 +33,10 @@ THRESHOLD_BYTES = 10 * 1024**2  # 10 MB
 
 # --- Local config ---
 BATCH_SIZE = 1_000
-MAX_WORKERS = 8  # concurrent batches (limits RAM/CPU pressure)
+MAX_WORKERS = 2  # concurrent batches (limits RAM/CPU pressure)
 S5CMD_WORKERS = 8  # s5cmd defaults to 256 — cap it for local runs
 TRANSFORM_WORKERS = (
-    4  # transform threads per batch (total = MAX_WORKERS × TRANSFORM_WORKERS)
+    16  # transform threads per batch (total = MAX_WORKERS × TRANSFORM_WORKERS)
 )
 
 # --- Live Inventory Source config
@@ -68,7 +72,7 @@ _greedy_partitioner = GreedyBatchPartitioner(
 _file_fetcher = S5CMDFetcher(num_workers=S5CMD_WORKERS, anon=True)
 
 # --- Metadata extractor ---
-_unstructured_netcdf_extractor = UnstructuedNetCDFExtractor()
+_attribute_netcdf_extractor = AttributeNetCDFExtractor()
 
 # --- Sink config ---
 _data_index_catalog_config = S3TablesCatalogConfig(
@@ -104,7 +108,8 @@ def run_index_local(
     partitioner: GreedyBatchPartitioner = _greedy_partitioner,
     fetcher: S3Fetcher | S5CMDFetcher | ThresholdFileFetcher = _file_fetcher,
     extractor: NetCDFExtractor
-    | UnstructuedNetCDFExtractor = _unstructured_netcdf_extractor,
+    | UnstructuedNetCDFExtractor
+    | AttributeNetCDFExtractor = _attribute_netcdf_extractor,
     structured_sink: StructuredParquetSink
     | StructuredS3TableSink = _structured_s3_table_sink,
     unstructured_sink: UnstructuredParquetSink

--- a/src/data_index/defaults/local.py
+++ b/src/data_index/defaults/local.py
@@ -36,7 +36,7 @@ BATCH_SIZE = 1_000
 MAX_WORKERS = 2  # concurrent batches (limits RAM/CPU pressure)
 S5CMD_WORKERS = 8  # s5cmd defaults to 256 — cap it for local runs
 TRANSFORM_WORKERS = (
-    16  # transform threads per batch (total = MAX_WORKERS × TRANSFORM_WORKERS)
+    12  # transform threads per batch (total = MAX_WORKERS × TRANSFORM_WORKERS)
 )
 
 # --- Live Inventory Source config

--- a/src/data_index/defaults/local_subset.py
+++ b/src/data_index/defaults/local_subset.py
@@ -1,0 +1,65 @@
+import pathlib
+
+import prefect
+
+from data_index.inventory_source import LiveS3InventorySource, ParquetInventorySource
+from data_index.inventory_source.live_s3_facility_subset import (
+    LiveS3InventorySourceFacilitySubset,
+)
+from data_index.structured_sink import StructuredParquetSink
+from data_index.unstructured_sink import UnstructuredParquetSink
+
+from .local import (
+    MAX_WORKERS,
+    OUT_DIR,
+    TRANSFORM_WORKERS,
+    extractor,
+    fetcher,
+    inventory_table_config,
+    inventory_table_scan_config,
+    partitioner,
+    run_index_local,
+)
+
+live_inventory_source = LiveS3InventorySourceFacilitySubset(
+    table_config=inventory_table_config,
+    table_scan_config=inventory_table_scan_config,
+    path=pathlib.Path(".extract/s3_metadata"),
+    skip_if_exists=True,
+    subset_per_facility=10_000,
+)
+
+structured_sink = StructuredParquetSink(path=OUT_DIR / "structured_metadata.parquet")
+unstructured_sink = UnstructuredParquetSink(
+    path=OUT_DIR / "unstructured_metadata.parquet"
+)
+
+
+@prefect.flow
+def run_index_local_subset(
+    inventory_source: LiveS3InventorySource
+    | ParquetInventorySource = live_inventory_source,
+    partitioner=partitioner,
+    fetcher=fetcher,
+    extractor=extractor,
+    structured_sink=structured_sink,
+    unstructured_sink=unstructured_sink,
+    metadata_factory=None,
+    transform_max_workers: int | None = TRANSFORM_WORKERS,
+):
+    run_index_local.with_options(
+        task_runner=prefect.task_runners.ThreadPoolTaskRunner(max_workers=MAX_WORKERS)
+    )(
+        inventory_source=inventory_source,
+        partitioner=partitioner,
+        fetcher=fetcher,
+        extractor=extractor,
+        structured_sink=structured_sink,
+        unstructured_sink=unstructured_sink,
+        metadata_factory=metadata_factory,
+        transform_max_workers=transform_max_workers,
+    )
+
+
+if __name__ == "__main__":
+    run_index_local_subset()

--- a/src/data_index/defaults/local_subset.py
+++ b/src/data_index/defaults/local_subset.py
@@ -2,6 +2,7 @@ import pathlib
 
 import prefect
 
+from data_index.file_fetcher import S3Fetcher, S5CMDFetcher, ThresholdFileFetcher
 from data_index.iceberg_config import (
     IcebergTableConfig,
     S3TablesCatalogConfig,
@@ -18,9 +19,9 @@ from data_index.unstructured_sink import (
 
 from .local import (
     MAX_WORKERS,
+    S5CMD_WORKERS,
     TRANSFORM_WORKERS,
     extractor,
-    fetcher,
     inventory_table_config,
     inventory_table_scan_config,
     partitioner,
@@ -32,7 +33,7 @@ live_inventory_source = LiveS3InventorySourceFacilitySubset(
     table_scan_config=inventory_table_scan_config,
     path=pathlib.Path(".extract/s3_metadata"),
     skip_if_exists=True,
-    subset_per_facility=10_000,
+    subset_per_facility=2_000,
 )
 
 # --- Sink config ---
@@ -59,6 +60,14 @@ unstructured_metadata_table_config = IcebergTableConfig(
 
 unstructured_sink = UnstructuredS3TableSink(
     iceberg_table_config=unstructured_metadata_table_config,
+)
+
+# --- Fetcher ---
+size_threshold_bytes = 1024**2 * 10
+fetcher = ThresholdFileFetcher(
+    size_threshold_bytes=size_threshold_bytes,
+    disk_fetcher=S5CMDFetcher(num_workers=S5CMD_WORKERS, anon=True),
+    cloud_fetcher=S3Fetcher(block_size=size_threshold_bytes),
 )
 
 

--- a/src/data_index/defaults/local_subset.py
+++ b/src/data_index/defaults/local_subset.py
@@ -2,16 +2,22 @@ import pathlib
 
 import prefect
 
+from data_index.iceberg_config import (
+    IcebergTableConfig,
+    S3TablesCatalogConfig,
+)
 from data_index.inventory_source import LiveS3InventorySource, ParquetInventorySource
 from data_index.inventory_source.live_s3_facility_subset import (
     LiveS3InventorySourceFacilitySubset,
 )
-from data_index.structured_sink import StructuredParquetSink
-from data_index.unstructured_sink import UnstructuredParquetSink
+from data_index.structured_metadata import StructuredMetadata
+from data_index.structured_sink import StructuredS3TableSink
+from data_index.unstructured_sink import (
+    UnstructuredS3TableSink,
+)
 
 from .local import (
     MAX_WORKERS,
-    OUT_DIR,
     TRANSFORM_WORKERS,
     extractor,
     fetcher,
@@ -29,9 +35,30 @@ live_inventory_source = LiveS3InventorySourceFacilitySubset(
     subset_per_facility=10_000,
 )
 
-structured_sink = StructuredParquetSink(path=OUT_DIR / "structured_metadata.parquet")
-unstructured_sink = UnstructuredParquetSink(
-    path=OUT_DIR / "unstructured_metadata.parquet"
+# --- Sink config ---
+data_index_catalog_config = S3TablesCatalogConfig(
+    region="ap-southeast-2",
+    arn="arn:aws:s3tables:ap-southeast-2:704910415367:bucket/data-index",
+)
+
+structured_metadata_table_config = IcebergTableConfig(
+    catalog_config=data_index_catalog_config,
+    namespace="data_index",
+    table_name=f"structured_metadata_v{StructuredMetadata.SCHEMA_VERSION}",
+)
+
+structured_sink = StructuredS3TableSink(
+    iceberg_table_config=structured_metadata_table_config,
+)
+
+unstructured_metadata_table_config = IcebergTableConfig(
+    catalog_config=data_index_catalog_config,
+    namespace="data_index",
+    table_name="unstructured_metadata",
+)
+
+unstructured_sink = UnstructuredS3TableSink(
+    iceberg_table_config=unstructured_metadata_table_config,
 )
 
 

--- a/src/data_index/inventory_source/live_s3.py
+++ b/src/data_index/inventory_source/live_s3.py
@@ -42,6 +42,15 @@ class LiveS3InventorySource(pydantic.BaseModel):
         live_lf = transform(inventory_lf)
         load(live_lf, path=self.path)
 
+    @staticmethod
+    def _s3_uri_column() -> polars.Expr:
+        return polars.concat_str(
+            polars.lit("s3://"),
+            polars.col("bucket"),
+            polars.lit("/"),
+            polars.col("key"),
+        ).alias("s3_uri")
+
     def inventory(self) -> polars.DataFrame:
         if not (self.skip_if_exists and self._has_data()):
             self._run_etl()
@@ -49,12 +58,7 @@ class LiveS3InventorySource(pydantic.BaseModel):
         return (
             polars.scan_parquet(self.path / "**" / "*.parquet")
             .select(
-                polars.concat_str(
-                    polars.lit("s3://"),
-                    polars.col("bucket"),
-                    polars.lit("/"),
-                    polars.col("key"),
-                ).alias("s3_uri"),
+                self._s3_uri_column(),
                 polars.col("size"),
             )
             .collect()

--- a/src/data_index/inventory_source/live_s3_facility_subset.py
+++ b/src/data_index/inventory_source/live_s3_facility_subset.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pathlib
+
+import polars
+import pydantic
+
+from data_index.inventory_source import LiveS3InventorySource
+
+_DEFAULT_PATH = pathlib.Path(".extract/s3_metadata")
+_INVENTORY_PARQUET = pathlib.Path("imos-data.inventory.parquet")
+
+
+class LiveS3InventorySourceFacilitySubset(LiveS3InventorySource):
+    """InventorySource that runs the s3_metadata ETL to materialise the live S3 inventory
+    table to disk, then reads it back as a DataFrame with `s3_uri` and `size` columns.
+
+    If skip_if_exists=True (default) and the target path already contains parquet files,
+    the ETL is skipped and the existing data is returned directly.
+    """
+
+    subset_per_facility: int = pydantic.Field(default=10_000, ge=1)
+
+    def inventory(self) -> polars.DataFrame:
+        """
+        Return a subset from each facility
+        """
+        if not (self.skip_if_exists and self._has_data()):
+            self._run_etl()
+
+        inventory_scan = polars.scan_parquet(self.path / "**" / "*.parquet")
+
+        # Find facilities, defined as second part of path
+        facilities = (
+            inventory_scan.select(
+                polars.col("key")
+                .str.extract(pattern=r"^IMOS/([^/]+)/", group_index=1)
+                .alias("facility"),
+            )
+            .drop_nulls()
+            .unique()
+            .collect()
+            .get_column("facility")
+            .to_list()
+        )
+
+        # Takes samples of size `subset_per_facility` per facility
+        sampled_slices: list[polars.DataFrame] = []
+        for facility in facilities:
+            facility_rows = (
+                polars.scan_parquet(self.path / "**" / "*.parquet")
+                .filter(polars.col("key").str.starts_with(f"IMOS/{facility}/"))
+                .select("bucket", "key", "size")
+                .collect()
+            )
+            if facility_rows.is_empty():
+                continue
+
+            sample_n = min(self.subset_per_facility, facility_rows.height)
+            sampled_slices.append(
+                facility_rows.sample(n=sample_n, with_replacement=False, shuffle=True)
+            )
+
+        # No samples case
+        if not sampled_slices:
+            return polars.DataFrame(
+                schema={"s3_uri": polars.String, "size": polars.Int64}
+            )
+
+        # Concat and adjust to s3_uri
+        return polars.concat(sampled_slices).select(
+            self._s3_uri_column(),
+            polars.col("size"),
+        )

--- a/src/data_index/load.py
+++ b/src/data_index/load.py
@@ -24,7 +24,9 @@ def load(
     succeeded = [r for r in extraction_results if r.status == "succeeded"]
 
     structured = [
-        r.structured_metadata for r in succeeded if r.structured_metadata is not None
+        result.structured_metadata
+        for result in succeeded
+        if result.structured_metadata is not None
     ]
     structured_sink.write(structured)
     logger.info(f"Wrote {len(structured)} structured metadata rows")

--- a/src/data_index/metadata_extractor/__init__.py
+++ b/src/data_index/metadata_extractor/__init__.py
@@ -1,7 +1,9 @@
+from .attribute_netcdf_extractor import AttributeNetCDFExtractor
 from .netcdf_extractor import NetCDFExtractor
 from .unstructured_netcdf_extractor import UnstructuedNetCDFExtractor
 
 __all__ = [
     "NetCDFExtractor",
     "UnstructuedNetCDFExtractor",
+    "AttributeNetCDFExtractor",
 ]

--- a/src/data_index/metadata_extractor/_sanitize.py
+++ b/src/data_index/metadata_extractor/_sanitize.py
@@ -5,15 +5,41 @@ import orjson
 def _serialize_with_orjson(data: dict) -> dict:
     """Sanitise numpy/xarray types to native Python primitives via orjson round-trip.
     Faster than recursive Python traversal for large metadata dicts."""
-    return orjson.loads(orjson.dumps(data, option=orjson.OPT_SERIALIZE_NUMPY))
+    try:
+        return orjson.loads(orjson.dumps(data, option=orjson.OPT_SERIALIZE_NUMPY))
+    except TypeError as exc:
+        # Some NetCDF attrs contain lone UTF-16 surrogates that orjson rejects.
+        if "str is not valid UTF-8" not in str(exc):
+            raise
+        return orjson.loads(
+            orjson.dumps(
+                _sanitize_for_json(data),
+                option=orjson.OPT_SERIALIZE_NUMPY,
+            )
+        )
+
+
+def _sanitize_string(data: str) -> str:
+    """Replace invalid UTF-8 code points with escaped unicode sequences."""
+    return data.encode("utf-8", errors="backslashreplace").decode("utf-8")
+
+
+def _sanitize_dict_key(data) -> str:
+    if isinstance(data, bytes):
+        return _sanitize_string(data.decode("utf-8", errors="backslashreplace"))
+    if isinstance(data, str):
+        return _sanitize_string(data)
+    return _sanitize_string(str(data))
 
 
 def _sanitize_for_json(data):
     """Recursively convert numpy/xarray types to native Python primitives."""
     if isinstance(data, dict):
-        return {k: _sanitize_for_json(v) for k, v in data.items()}
+        return {_sanitize_dict_key(k): _sanitize_for_json(v) for k, v in data.items()}
     elif isinstance(data, (list, tuple)):
         return [_sanitize_for_json(v) for v in data]
+    elif isinstance(data, str):
+        return _sanitize_string(data)
     elif isinstance(data, numpy.bool_):
         return bool(data)
     elif isinstance(data, (numpy.integer, numpy.int64, numpy.int32)):
@@ -21,8 +47,8 @@ def _sanitize_for_json(data):
     elif isinstance(data, (numpy.floating, numpy.float64, numpy.float32)):
         return float(data)
     elif isinstance(data, numpy.ndarray):
-        return data.tolist()
+        return _sanitize_for_json(data.tolist())
     # Handle cases where attributes might be byte-strings
     elif isinstance(data, bytes):
-        return data.decode("utf-8", errors="ignore")
+        return data.decode("utf-8", errors="backslashreplace")
     return data

--- a/src/data_index/metadata_extractor/attribute_netcdf_extractor.py
+++ b/src/data_index/metadata_extractor/attribute_netcdf_extractor.py
@@ -8,7 +8,7 @@ from data_index.protocols import RawExtractionResult, XarrayHandle
 from data_index.structured_metadata import StructuredMetadata
 
 
-class UnstructuedNetCDFExtractor(pydantic.BaseModel):
+class AttributeNetCDFExtractor(pydantic.BaseModel):
     """MetadataExtractor implementation for CF-compliant NetCDF files using xarray."""
 
     def extract(self, handle: XarrayHandle) -> RawExtractionResult:
@@ -44,25 +44,47 @@ class UnstructuedNetCDFExtractor(pydantic.BaseModel):
         file_format: str | None = None,
     ) -> StructuredMetadata:
         """
-        Dummy class that
+        Structured data extraction from attributes
         """
-        # TODO: Add the CF mapping from global attributes
-        # TODO: Get Marty/core team to check over first pass structured metadata
-        # TODO: Also include:
-        # `Conventions`
-        # `Site`, `Platform` and `Deployment`
-        # `keywords`
-        return StructuredMetadata(
-            s3_uri=s3_uri,
-            file_format=file_format,
-            lat_min=None,
-            lat_max=None,
-            lon_min=None,
-            lon_max=None,
-            time_min=None,
-            time_max=None,
-            crs=None,
-        )
+        metadata_kwargs = {
+            "s3_uri": s3_uri,
+            "file_format": file_format,
+        }
+
+        attributes_map: dict[str, tuple[str, type]] = {
+            # Temporal Spatial
+            "lat_min": ("geospatial_lat_min", float),
+            "lat_max": ("geospatial_lat_max", float),
+            "lon_min": ("geospatial_lon_min", float),
+            "lon_max": ("geospatial_lon_max", float),
+            "time_min": ("time_coverage_start", str),
+            "time_max": ("time_coverage_end", str),
+            # Keywords
+            "keywords": ("keywords", str),
+            "conventions": ("Conventions", str),
+            "file_version": ("file_version", str),
+            "file_version_quality_control": ("file_version_quality_control", str),
+            "metadata_uuid": ("metadata_uuid", str),
+            # Site Platform Deployment
+            "platform_code": ("platform_code", str),
+            "site_code": ("site_code", str),
+            "deployment_code": ("deployment_code", str),
+            # Instrumentation
+            "instrument": ("instrument", str),
+        }
+
+        errors = {}
+
+        # Convert attribute
+        for attribute, (key, _type) in attributes_map.items():
+            val = ds.attrs.get(key)
+            try:
+                metadata_kwargs[attribute] = _type(val) if val is not None else None
+            except (ValueError, TypeError) as e:
+                metadata_kwargs[attribute] = None
+                errors[attribute] = e
+
+        return StructuredMetadata(**metadata_kwargs)
 
     def _extract_unstructured(
         self,

--- a/src/data_index/metadata_extractor/attribute_netcdf_extractor.py
+++ b/src/data_index/metadata_extractor/attribute_netcdf_extractor.py
@@ -9,9 +9,15 @@ from data_index.structured_metadata import StructuredMetadata
 
 
 class AttributeNetCDFExtractor(pydantic.BaseModel):
-    """MetadataExtractor implementation for CF-compliant NetCDF files using xarray."""
+    """Metadata extractor for CF-compliant NetCDF datasets via xarray."""
 
     def extract(self, handle: XarrayHandle) -> RawExtractionResult:
+        """Extract structured and unstructured metadata for one handle.
+
+        :param handle: Dataset handle to read from.
+        :returns: Extraction result with success/failure status.
+        """
+
         try:
             structured = self._extract_structured(
                 ds=handle.ds,
@@ -43,54 +49,134 @@ class AttributeNetCDFExtractor(pydantic.BaseModel):
         s3_uri: str,
         file_format: str | None = None,
     ) -> StructuredMetadata:
+        """Build structured metadata row from global attributes and dataset structure.
+
+        :param ds: Open xarray dataset.
+        :param s3_uri: Source S3 URI for the row.
+        :param file_format: File format derived from magic bytes.
+        :returns: Structured metadata row.
         """
-        Structured data extraction from attributes
-        """
+
         metadata_kwargs = {
             "s3_uri": s3_uri,
             "file_format": file_format,
         }
 
-        attributes_map: dict[str, tuple[str, type]] = {
+        attributes_map: dict[str, tuple[list[str], type]] = {
             # Temporal Spatial
-            "lat_min": ("geospatial_lat_min", float),
-            "lat_max": ("geospatial_lat_max", float),
-            "lon_min": ("geospatial_lon_min", float),
-            "lon_max": ("geospatial_lon_max", float),
-            "time_min": ("time_coverage_start", str),
-            "time_max": ("time_coverage_end", str),
+            "lat_min": (["geospatial_lat_min"], float),
+            "lat_max": (["geospatial_lat_max"], float),
+            "lon_min": (["geospatial_lon_min"], float),
+            "lon_max": (["geospatial_lon_max"], float),
+            "time_min": (["time_coverage_start"], str),
+            "time_max": (["time_coverage_end"], str),
             # Keywords
-            "keywords": ("keywords", str),
-            "conventions": ("Conventions", str),
-            "file_version": ("file_version", str),
-            "file_version_quality_control": ("file_version_quality_control", str),
-            "metadata_uuid": ("metadata_uuid", str),
+            "keywords": (["keywords"], str),
+            "conventions": (["Conventions", "conventions"], str),
+            "file_version": (["file_version"], str),
+            "metadata_uuid": (["metadata_uuid"], str),
             # Site Platform Deployment
-            "platform_code": ("platform_code", str),
-            "site_code": ("site_code", str),
-            "deployment_code": ("deployment_code", str),
+            "platform_code": (["platform_code"], str),
+            "site_code": (["site_code"], str),
+            "deployment_code": (["deployment_code"], str),
             # Instrumentation
-            "instrument": ("instrument", str),
+            "instrument": (["instrument"], str),
+            "feature_type": (["featureType", "feature_type"], str),
+            "instrument_serial_number": (
+                ["instrument_serial_number", "instrumentSerialNumber"],
+                str,
+            ),
         }
 
         errors = {}
 
         # Convert attribute
-        for attribute, (key, _type) in attributes_map.items():
-            val = ds.attrs.get(key)
+        for attribute, (aliases, _type) in attributes_map.items():
+            resolved_key = self._resolve_attribute_key(ds.attrs, aliases)
+            val = ds.attrs.get(resolved_key) if resolved_key is not None else None
             try:
                 metadata_kwargs[attribute] = _type(val) if val is not None else None
             except (ValueError, TypeError) as e:
                 metadata_kwargs[attribute] = None
                 errors[attribute] = e
 
+        metadata_kwargs["dimensions"] = self._sorted_or_none(ds.dims)
+        metadata_kwargs["variables"] = self._sorted_or_none(ds.data_vars)
+        metadata_kwargs["standard_names"] = self._extract_standard_names(ds)
+
         return StructuredMetadata(**metadata_kwargs)
+
+    @staticmethod
+    def _normalize_attr_key(key: str) -> str:
+        """Normalize attribute keys for discrepancy-tolerant matching.
+
+        :param key: Raw attribute key.
+        :returns: Lower-cased key with ``_`` and ``-`` removed.
+        """
+
+        return key.lower().replace("_", "").replace("-", "")
+
+    @classmethod
+    def _resolve_attribute_key(cls, attrs: dict, aliases: list[str]) -> str | None:
+        """Resolve attribute key by alias priority then normalized fallback.
+
+        :param attrs: Dataset global attributes.
+        :param aliases: Ordered canonical aliases, highest priority first.
+        :returns: Matched attribute key from ``attrs`` or ``None``.
+        """
+
+        for alias in aliases:
+            if alias in attrs:
+                return alias
+
+        for alias in aliases:
+            normalized_alias = cls._normalize_attr_key(alias)
+            for key in attrs:
+                if (
+                    isinstance(key, str)
+                    and cls._normalize_attr_key(key) == normalized_alias
+                ):
+                    return key
+        return None
+
+    @staticmethod
+    def _sorted_or_none(values) -> list[str] | None:
+        """Return sorted unique string values, or ``None`` when empty.
+
+        :param values: Iterable-like values to normalize.
+        :returns: Sorted unique strings or ``None``.
+        """
+
+        normalized = sorted({str(value) for value in values})
+        return normalized or None
+
+    @classmethod
+    def _extract_standard_names(cls, ds: xarray.Dataset) -> list[str] | None:
+        """Collect unique ``standard_name`` values from vars and coords.
+
+        :param ds: Open xarray dataset.
+        :returns: Sorted unique standard names or ``None``.
+        """
+
+        standard_names = set()
+        for variable in list(ds.data_vars.values()) + list(ds.coords.values()):
+            value = variable.attrs.get("standard_name")
+            if isinstance(value, str) and value.strip():
+                standard_names.add(value)
+        return cls._sorted_or_none(standard_names)
 
     def _extract_unstructured(
         self,
         ds: xarray.Dataset,
         file_format: str | None = None,
     ) -> dict:
+        """Build unstructured metadata payload from dataset contents.
+
+        :param ds: Open xarray dataset.
+        :param file_format: File format derived from magic bytes.
+        :returns: JSON-serializable unstructured metadata dict.
+        """
+
         unstructured = {
             "file_format": file_format,
             "global_attrs": dict(ds.attrs),

--- a/src/data_index/metadata_extractor/netcdf_extractor.py
+++ b/src/data_index/metadata_extractor/netcdf_extractor.py
@@ -5,7 +5,8 @@ from data_index._collection import derive_collection
 from data_index.metadata_extractor._sanitize import (
     _serialize_with_orjson,
 )
-from data_index.protocols import RawExtractionResult, StructuredMetadata, XarrayHandle
+from data_index.protocols import RawExtractionResult, XarrayHandle
+from data_index.structured_metadata import StructuredMetadata
 
 
 class NetCDFExtractor(pydantic.BaseModel):

--- a/src/data_index/protocols.py
+++ b/src/data_index/protocols.py
@@ -6,40 +6,13 @@ import typing
 import polars
 import xarray
 
+import data_index.structured_metadata
+
 
 @dataclasses.dataclass
 class BatchEntry:
     uri: str
     size_bytes: int | None = None
-
-
-@dataclasses.dataclass
-class StructuredMetadata:
-    s3_uri: str
-    lat_min: float | None
-    lat_max: float | None
-    lon_min: float | None
-    lon_max: float | None
-    time_min: str | None
-    time_max: str | None
-    crs: str | None
-    file_format: str | None = None
-    collection: str | None = None
-
-    polars_schema: typing.ClassVar[polars.Schema] = polars.Schema(
-        {
-            "s3_uri": polars.String,
-            "lat_min": polars.Float64,
-            "lat_max": polars.Float64,
-            "lon_min": polars.Float64,
-            "lon_max": polars.Float64,
-            "time_min": polars.String,
-            "time_max": polars.String,
-            "crs": polars.String,
-            "file_format": polars.String,
-            "collection": polars.String,
-        }
-    )
 
 
 @typing.runtime_checkable
@@ -55,7 +28,7 @@ class RawExtractionResult:
     is a plain dict — persistence wrapping is the responsibility of transform."""
 
     s3_uri: str
-    structured_metadata: StructuredMetadata | None
+    structured_metadata: data_index.structured_metadata.StructuredMetadata | None
     unstructured_metadata: dict | None
     status: str  # "succeeded" or "failed"
     error: str | None = None
@@ -67,7 +40,7 @@ class ExtractionResult:
     UnstructuredMetadata handle (written by metadata_factory during transform)."""
 
     s3_uri: str
-    structured_metadata: StructuredMetadata | None
+    structured_metadata: data_index.structured_metadata.StructuredMetadata | None
     unstructured_metadata: UnstructuredMetadata | None
     status: str  # "succeeded" or "failed"
     error: str | None = None
@@ -108,7 +81,9 @@ class StructuredSink(typing.Protocol):
         """Prepare the target store before any writes (e.g. create directories or tables)."""
         ...
 
-    def write(self, data: list[StructuredMetadata]) -> None:
+    def write(
+        self, data: list[data_index.structured_metadata.StructuredMetadata]
+    ) -> None:
         """Persist Structured Metadata to a target store."""
         ...
 

--- a/src/data_index/structured_metadata.py
+++ b/src/data_index/structured_metadata.py
@@ -4,6 +4,8 @@ import typing
 
 import polars
 import pyarrow
+import pyiceberg.schema
+import pyiceberg.types
 
 
 @dataclasses.dataclass
@@ -111,5 +113,25 @@ class StructuredMetadata:
                     nullable=field["nullable"],
                 )
                 for field in cls._unpack_fields()
+            ]
+        )
+
+    @classmethod
+    def as_pyiceberg_schema(cls) -> pyiceberg.schema.Schema:
+        _PYICEBERG_TYPE_MAP = {
+            str: pyiceberg.types.StringType(),
+            float: pyiceberg.types.DoubleType(),
+            int: pyiceberg.types.LongType(),
+            bool: pyiceberg.types.BooleanType(),
+        }
+        return pyiceberg.schema.Schema(
+            *[
+                pyiceberg.types.NestedField(
+                    field_id=index,
+                    name=field["name"],
+                    field_type=_PYICEBERG_TYPE_MAP[field["type"]],
+                    required=not field["nullable"],
+                )
+                for index, field in enumerate(cls._unpack_fields(), start=1)
             ]
         )

--- a/src/data_index/structured_metadata.py
+++ b/src/data_index/structured_metadata.py
@@ -75,12 +75,16 @@ class StructuredMetadata:
     keywords: str | None = None
     conventions: str | None = None
     file_version: str | None = None
-    file_version_quality_control: str | None = None
     metadata_uuid: str | None = None
     platform_code: str | None = None
     site_code: str | None = None
     deployment_code: str | None = None
     instrument: str | None = None
+    feature_type: str | None = None
+    instrument_serial_number: str | None = None
+    dimensions: list[str] | None = None
+    variables: list[str] | None = None
+    standard_names: list[str] | None = None
     file_format: str | None = None
     collection: str | None = None
 
@@ -185,7 +189,13 @@ class StructuredMetadata:
             return scalar_map[type_spec.scalar_type]
         if type_spec.item_type is None:
             raise ValueError("List type missing element type")
-        return pyarrow.list_(cls._to_pyarrow_type(type_spec.item_type))
+        return pyarrow.list_(
+            pyarrow.field(
+                "item",
+                cls._to_pyarrow_type(type_spec.item_type),
+                nullable=False,
+            )
+        )
 
     @classmethod
     def _to_pyiceberg_type(

--- a/src/data_index/structured_metadata.py
+++ b/src/data_index/structured_metadata.py
@@ -64,6 +64,8 @@ class StructuredMetadata:
     schema generation.
     """
 
+    SCHEMA_VERSION: typing.ClassVar[int] = 1
+
     s3_uri: str
     lat_min: float | None = None
     lat_max: float | None = None

--- a/src/data_index/structured_metadata.py
+++ b/src/data_index/structured_metadata.py
@@ -8,8 +8,62 @@ import pyiceberg.schema
 import pyiceberg.types
 
 
+@dataclasses.dataclass(frozen=True)
+class _TypeSpec:
+    """Normalized internal representation of a field type.
+
+    :param kind: Type category, either ``"scalar"`` or ``"list"``.
+    :param scalar_type: Python scalar type when ``kind == "scalar"``.
+    :param item_type: Nested element type when ``kind == "list"``.
+    """
+
+    kind: typing.Literal["scalar", "list"]
+    scalar_type: type | None = None
+    item_type: "_TypeSpec | None" = None
+
+
+@dataclasses.dataclass(frozen=True)
+class _FieldSpec:
+    """Resolved schema information for one dataclass field.
+
+    :param name: Field name.
+    :param type_spec: Parsed type specification.
+    :param nullable: Whether the field allows ``None``.
+    """
+
+    name: str
+    type_spec: _TypeSpec
+    nullable: bool
+
+
+@dataclasses.dataclass
+class _PyIcebergIdAllocator:
+    """Allocates unique nested field IDs for PyIceberg complex types.
+
+    :param next_id: Next available ID.
+    """
+
+    next_id: int
+
+    def next_nested_id(self) -> int:
+        """Return next nested field ID and advance allocator.
+
+        :returns: Next unique nested ID.
+        """
+
+        nested_id = self.next_id
+        self.next_id += 1
+        return nested_id
+
+
 @dataclasses.dataclass
 class StructuredMetadata:
+    """Structured metadata row schema and backend schema converters.
+
+    ``StructuredMetadata`` is source-of-truth for Polars, PyArrow, and PyIceberg
+    schema generation.
+    """
+
     s3_uri: str
     lat_min: float | None = None
     lat_max: float | None = None
@@ -31,107 +85,186 @@ class StructuredMetadata:
     collection: str | None = None
 
     @classmethod
-    def _unpack_field(cls, field: dataclasses.Field):
-        """
-        Helper function to unpack the a dataclass field.
+    def _parse_annotation(cls, annotation) -> tuple[_TypeSpec, bool]:
+        """Parse a field annotation into internal type spec + nullable flag.
+
+        :param annotation: Field annotation from dataclass metadata.
+        :returns: ``(type_spec, nullable)``.
+        :raises ValueError: If annotation is unsupported or ambiguous.
         """
 
-        origin = typing.get_origin(tp=field.type)
-
-        # Parse union types
+        origin = typing.get_origin(tp=annotation)
         if origin in (typing.Union, types.UnionType):
-            # Get the unioned types
-            args = typing.get_args(field.type)
-
-            # If None in the union then it is nullable
-            if type(None) in args:
-                is_nullable = True
-
-            # Otherwise it is an invalid input
-            else:
+            args = typing.get_args(annotation)
+            nullable = type(None) in args
+            if not nullable:
                 raise ValueError(
-                    f"Cannot generate schema for union of two types (excluding None): {origin}"
+                    f"Cannot generate schema for union of two types (excluding None): {annotation}"
                 )
-
-            # Check what the remaining type is
-            remaining_types = [t for t in args if t is not type(None)]
-
-            return {
-                "name": field.name,
-                "type": remaining_types[0] if remaining_types else type(None),
-                "nullable": is_nullable,
-            }
-
-        # Parse non-union type
-        else:
-            return {
-                "name": field.name,
-                "type": field.type,
-                "nullable": False,
-            }
+            non_none_types = [item for item in args if item is not type(None)]
+            if len(non_none_types) != 1:
+                raise ValueError(
+                    f"Cannot generate schema for optional union with multiple concrete types: {annotation}"
+                )
+            return cls._parse_non_union_type(non_none_types[0]), True
+        return cls._parse_non_union_type(annotation), False
 
     @classmethod
-    def _unpack_fields(cls) -> dict:
-        """
-        Helper function to unpack the fields of a dataclass
+    def _parse_non_union_type(cls, annotation) -> _TypeSpec:
+        """Parse non-union annotations into a normalized type spec.
+
+        :param annotation: Annotation that is not a union.
+        :returns: Parsed type spec.
+        :raises ValueError: If type is unsupported or malformed.
         """
 
-        return [
-            cls._unpack_field(field=field)
-            for field in dataclasses.fields(class_or_instance=cls)
-        ]
+        origin = typing.get_origin(tp=annotation)
+        if origin is list:
+            args = typing.get_args(annotation)
+            if len(args) != 1:
+                raise ValueError(
+                    f"Cannot generate schema for list with zero or multiple element types: {annotation}"
+                )
+            return _TypeSpec(kind="list", item_type=cls._parse_non_union_type(args[0]))
+        if annotation in (str, float, int, bool):
+            return _TypeSpec(kind="scalar", scalar_type=annotation)
+        raise ValueError(f"Cannot generate schema for unsupported type: {annotation}")
 
     @classmethod
-    def as_polars_schema(cls) -> polars.Schema:
+    def _field_specs(cls) -> list[_FieldSpec]:
+        """Resolve dataclass fields into normalized field specs.
 
-        _POLARS_TYPE_MAP = {
+        :returns: Parsed field specifications in declaration order.
+        """
+
+        field_specs = []
+        for field in dataclasses.fields(class_or_instance=cls):
+            type_spec, nullable = cls._parse_annotation(field.type)
+            field_specs.append(
+                _FieldSpec(name=field.name, type_spec=type_spec, nullable=nullable)
+            )
+        return field_specs
+
+    @classmethod
+    def _to_polars_type(cls, type_spec: _TypeSpec):
+        """Convert internal type spec to Polars type.
+
+        :param type_spec: Parsed type spec.
+        :returns: Polars dtype for the spec.
+        :raises ValueError: If list type has no element type.
+        """
+
+        scalar_map = {
             str: polars.String,
             float: polars.Float64,
             int: polars.Int64,
             bool: polars.Boolean,
         }
-        return polars.Schema(
-            schema={
-                field["name"]: _POLARS_TYPE_MAP[field["type"]]
-                for field in cls._unpack_fields()
-            }
-        )
+        if type_spec.kind == "scalar":
+            return scalar_map[type_spec.scalar_type]
+        if type_spec.item_type is None:
+            raise ValueError("List type missing element type")
+        return polars.List(cls._to_polars_type(type_spec.item_type))
 
     @classmethod
-    def as_pyarrow_schema(cls) -> pyarrow.Schema:
-        _PYARROW_TYPE_MAP = {
+    def _to_pyarrow_type(cls, type_spec: _TypeSpec):
+        """Convert internal type spec to PyArrow type.
+
+        :param type_spec: Parsed type spec.
+        :returns: PyArrow type for the spec.
+        :raises ValueError: If list type has no element type.
+        """
+
+        scalar_map = {
             str: pyarrow.string(),
             float: pyarrow.float64(),
             int: pyarrow.int64(),
             bool: pyarrow.bool_(),
         }
-        return pyarrow.schema(
-            fields=[
-                pyarrow.field(
-                    field["name"],
-                    type=_PYARROW_TYPE_MAP[field["type"]],
-                    nullable=field["nullable"],
-                )
-                for field in cls._unpack_fields()
-            ]
-        )
+        if type_spec.kind == "scalar":
+            return scalar_map[type_spec.scalar_type]
+        if type_spec.item_type is None:
+            raise ValueError("List type missing element type")
+        return pyarrow.list_(cls._to_pyarrow_type(type_spec.item_type))
 
     @classmethod
-    def as_pyiceberg_schema(cls) -> pyiceberg.schema.Schema:
-        _PYICEBERG_TYPE_MAP = {
+    def _to_pyiceberg_type(
+        cls, type_spec: _TypeSpec, id_allocator: _PyIcebergIdAllocator
+    ):
+        """Convert internal type spec to PyIceberg type.
+
+        :param type_spec: Parsed type spec.
+        :param id_allocator: Nested field ID allocator.
+        :returns: PyIceberg type for the spec.
+        :raises ValueError: If list type has no element type.
+        """
+
+        scalar_map = {
             str: pyiceberg.types.StringType(),
             float: pyiceberg.types.DoubleType(),
             int: pyiceberg.types.LongType(),
             bool: pyiceberg.types.BooleanType(),
         }
+        if type_spec.kind == "scalar":
+            return scalar_map[type_spec.scalar_type]
+        if type_spec.item_type is None:
+            raise ValueError("List type missing element type")
+        return pyiceberg.types.ListType(
+            element_id=id_allocator.next_nested_id(),
+            element=cls._to_pyiceberg_type(type_spec.item_type, id_allocator),
+        )
+
+    @classmethod
+    def as_polars_schema(cls) -> polars.Schema:
+        """Build Polars schema from ``StructuredMetadata`` annotations.
+
+        :returns: Polars schema matching dataclass field order.
+        """
+
+        field_specs = cls._field_specs()
+        return polars.Schema(
+            schema={
+                field.name: cls._to_polars_type(field.type_spec)
+                for field in field_specs
+            }
+        )
+
+    @classmethod
+    def as_pyarrow_schema(cls) -> pyarrow.Schema:
+        """Build PyArrow schema from ``StructuredMetadata`` annotations.
+
+        :returns: PyArrow schema with nullable flags preserved.
+        """
+
+        field_specs = cls._field_specs()
+        return pyarrow.schema(
+            fields=[
+                pyarrow.field(
+                    field.name,
+                    type=cls._to_pyarrow_type(field.type_spec),
+                    nullable=field.nullable,
+                )
+                for field in field_specs
+            ]
+        )
+
+    @classmethod
+    def as_pyiceberg_schema(cls) -> pyiceberg.schema.Schema:
+        """Build PyIceberg schema from ``StructuredMetadata`` annotations.
+
+        :returns: PyIceberg schema with deterministic field IDs.
+        """
+
+        field_specs = cls._field_specs()
+        id_allocator = _PyIcebergIdAllocator(next_id=len(field_specs) + 1)
         return pyiceberg.schema.Schema(
             *[
                 pyiceberg.types.NestedField(
                     field_id=index,
-                    name=field["name"],
-                    field_type=_PYICEBERG_TYPE_MAP[field["type"]],
-                    required=not field["nullable"],
+                    name=field.name,
+                    field_type=cls._to_pyiceberg_type(field.type_spec, id_allocator),
+                    required=not field.nullable,
                 )
-                for index, field in enumerate(cls._unpack_fields(), start=1)
+                for index, field in enumerate(field_specs, start=1)
             ]
         )

--- a/src/data_index/structured_metadata.py
+++ b/src/data_index/structured_metadata.py
@@ -1,0 +1,115 @@
+import dataclasses
+import types
+import typing
+
+import polars
+import pyarrow
+
+
+@dataclasses.dataclass
+class StructuredMetadata:
+    s3_uri: str
+    lat_min: float | None = None
+    lat_max: float | None = None
+    lon_min: float | None = None
+    lon_max: float | None = None
+    time_min: str | None = None
+    time_max: str | None = None
+    crs: str | None = None
+    keywords: str | None = None
+    conventions: str | None = None
+    file_version: str | None = None
+    file_version_quality_control: str | None = None
+    metadata_uuid: str | None = None
+    platform_code: str | None = None
+    site_code: str | None = None
+    deployment_code: str | None = None
+    instrument: str | None = None
+    file_format: str | None = None
+    collection: str | None = None
+
+    @classmethod
+    def _unpack_field(cls, field: dataclasses.Field):
+        """
+        Helper function to unpack the a dataclass field.
+        """
+
+        origin = typing.get_origin(tp=field.type)
+
+        # Parse union types
+        if origin in (typing.Union, types.UnionType):
+            # Get the unioned types
+            args = typing.get_args(field.type)
+
+            # If None in the union then it is nullable
+            if type(None) in args:
+                is_nullable = True
+
+            # Otherwise it is an invalid input
+            else:
+                raise ValueError(
+                    f"Cannot generate schema for union of two types (excluding None): {origin}"
+                )
+
+            # Check what the remaining type is
+            remaining_types = [t for t in args if t is not type(None)]
+
+            return {
+                "name": field.name,
+                "type": remaining_types[0] if remaining_types else type(None),
+                "nullable": is_nullable,
+            }
+
+        # Parse non-union type
+        else:
+            return {
+                "name": field.name,
+                "type": field.type,
+                "nullable": False,
+            }
+
+    @classmethod
+    def _unpack_fields(cls) -> dict:
+        """
+        Helper function to unpack the fields of a dataclass
+        """
+
+        return [
+            cls._unpack_field(field=field)
+            for field in dataclasses.fields(class_or_instance=cls)
+        ]
+
+    @classmethod
+    def as_polars_schema(cls) -> polars.Schema:
+
+        _POLARS_TYPE_MAP = {
+            str: polars.String,
+            float: polars.Float64,
+            int: polars.Int64,
+            bool: polars.Boolean,
+        }
+        return polars.Schema(
+            schema={
+                field["name"]: _POLARS_TYPE_MAP[field["type"]]
+                for field in cls._unpack_fields()
+            }
+        )
+
+    @classmethod
+    def as_pyarrow_schema(cls) -> pyarrow.Schema:
+        _PYARROW_TYPE_MAP = {
+            str: pyarrow.string(),
+            float: pyarrow.float64(),
+            int: pyarrow.int64(),
+            bool: pyarrow.bool_(),
+        }
+        return pyarrow.schema(
+            fields=[
+                pyarrow.field(
+                    field["name"],
+                    type=_PYARROW_TYPE_MAP[field["type"]],
+                    nullable=field["nullable"],
+                )
+                for field in cls._unpack_fields()
+            ]
+        )

--- a/src/data_index/structured_sink/parquet_sink.py
+++ b/src/data_index/structured_sink/parquet_sink.py
@@ -3,7 +3,7 @@ import pathlib
 
 import polars
 
-from data_index.protocols import StructuredMetadata
+from data_index.structured_metadata import StructuredMetadata
 
 
 class ParquetSink:
@@ -20,10 +20,11 @@ class ParquetSink:
 
     def write(self, data: list[StructuredMetadata]) -> None:
         rows = [dataclasses.asdict(row) for row in data]
+        schema = StructuredMetadata.as_polars_schema()
         df = (
-            polars.DataFrame(rows, schema=StructuredMetadata.polars_schema)
+            polars.DataFrame(rows, schema=schema)
             if rows
-            else polars.DataFrame(schema=StructuredMetadata.polars_schema)
+            else polars.DataFrame(schema=schema)
         )
         self.path.parent.mkdir(parents=True, exist_ok=True)
         df.write_parquet(self.path)

--- a/src/data_index/structured_sink/parquet_sink.py
+++ b/src/data_index/structured_sink/parquet_sink.py
@@ -27,4 +27,9 @@ class ParquetSink:
             else polars.DataFrame(schema=schema)
         )
         self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.exists():
+            if not rows:
+                return
+            existing_df = polars.read_parquet(self.path)
+            df = polars.concat([existing_df, df], how="vertical")
         df.write_parquet(self.path)

--- a/src/data_index/structured_sink/s3_table_sink.py
+++ b/src/data_index/structured_sink/s3_table_sink.py
@@ -13,12 +13,10 @@ from pyiceberg.exceptions import (
     TableAlreadyExistsError,
 )
 from pyiceberg.partitioning import PartitionSpec
-from pyiceberg.schema import Schema
 from pyiceberg.table import Table
-from pyiceberg.types import DoubleType, NestedField, StringType
 
 from data_index.iceberg_config.iceberg_table_config import IcebergTableConfig
-from data_index.protocols import StructuredMetadata
+from data_index.structured_metadata import StructuredMetadata
 
 _MAX_RETRIES = 5
 _BASE_BACKOFF = 0.5
@@ -32,40 +30,6 @@ class StructuredS3TableSink(pydantic.BaseModel):
     exponential backoff.
     """
 
-    _ICEBERG_SCHEMA: Schema = pydantic.PrivateAttr(
-        default_factory=lambda: Schema(
-            NestedField(
-                field_id=1, name="s3_uri", field_type=StringType(), required=True
-            ),
-            NestedField(
-                field_id=2, name="lat_min", field_type=DoubleType(), required=False
-            ),
-            NestedField(
-                field_id=3, name="lat_max", field_type=DoubleType(), required=False
-            ),
-            NestedField(
-                field_id=4, name="lon_min", field_type=DoubleType(), required=False
-            ),
-            NestedField(
-                field_id=5, name="lon_max", field_type=DoubleType(), required=False
-            ),
-            NestedField(
-                field_id=6, name="time_min", field_type=StringType(), required=False
-            ),
-            NestedField(
-                field_id=7, name="time_max", field_type=StringType(), required=False
-            ),
-            NestedField(
-                field_id=8, name="crs", field_type=StringType(), required=False
-            ),
-            NestedField(
-                field_id=9, name="file_format", field_type=StringType(), required=False
-            ),
-            NestedField(
-                field_id=10, name="collection", field_type=StringType(), required=False
-            ),
-        ),
-    )
     _instances: dict = pydantic.PrivateAttr(default_factory=lambda: {})
 
     iceberg_table_config: IcebergTableConfig
@@ -100,11 +64,12 @@ class StructuredS3TableSink(pydantic.BaseModel):
                     self.iceberg_table_config.namespace,
                     self.iceberg_table_config.table_name,
                 ),
-                schema=self._ICEBERG_SCHEMA,
+                schema=StructuredMetadata.as_pyiceberg_schema(),
                 partition_spec=partition_spec or PartitionSpec(),
             )
         except TableAlreadyExistsError:
             pass
+        self._evolve_schema()
 
     def write(self, data: list[StructuredMetadata]) -> None:
         if not data:
@@ -122,39 +87,23 @@ class StructuredS3TableSink(pydantic.BaseModel):
                     random.uniform(_BASE_BACKOFF, _BASE_BACKOFF * 2) * (2**attempt)
                 )
 
+    def _evolve_schema(self) -> None:
+        desired_schema = StructuredMetadata.as_pyiceberg_schema()
+        for attempt in range(_MAX_RETRIES):
+            try:
+                self.table.update_schema().union_by_name(desired_schema).commit()
+                return
+            except CommitFailedException:
+                if attempt == _MAX_RETRIES - 1:
+                    raise
+                self.table.refresh()
+                time.sleep(
+                    random.uniform(_BASE_BACKOFF, _BASE_BACKOFF * 2) * (2**attempt)
+                )
+
     @staticmethod
     def _to_arrow(data: list[StructuredMetadata]) -> pa.Table:
-        rows = [dataclasses.asdict(row) for row in data]
-        schema = pa.schema(
-            [
-                pa.field("s3_uri", pa.string(), nullable=False),
-                pa.field("lat_min", pa.float64(), nullable=True),
-                pa.field("lat_max", pa.float64(), nullable=True),
-                pa.field("lon_min", pa.float64(), nullable=True),
-                pa.field("lon_max", pa.float64(), nullable=True),
-                pa.field("time_min", pa.string(), nullable=True),
-                pa.field("time_max", pa.string(), nullable=True),
-                pa.field("crs", pa.string(), nullable=True),
-                pa.field("file_format", pa.string(), nullable=True),
-                pa.field("collection", pa.string(), nullable=True),
-            ]
-        )
-        return pa.table(
-            {
-                "s3_uri": pa.array([r["s3_uri"] for r in rows], type=pa.string()),
-                "lat_min": pa.array([r["lat_min"] for r in rows], type=pa.float64()),
-                "lat_max": pa.array([r["lat_max"] for r in rows], type=pa.float64()),
-                "lon_min": pa.array([r["lon_min"] for r in rows], type=pa.float64()),
-                "lon_max": pa.array([r["lon_max"] for r in rows], type=pa.float64()),
-                "time_min": pa.array([r["time_min"] for r in rows], type=pa.string()),
-                "time_max": pa.array([r["time_max"] for r in rows], type=pa.string()),
-                "crs": pa.array([r["crs"] for r in rows], type=pa.string()),
-                "file_format": pa.array(
-                    [r["file_format"] for r in rows], type=pa.string()
-                ),
-                "collection": pa.array(
-                    [r["collection"] for r in rows], type=pa.string()
-                ),
-            },
-            schema=schema,
+        return pa.Table.from_pylist(
+            [dataclasses.asdict(row) for row in data],
+            schema=StructuredMetadata.as_pyarrow_schema(),
         )

--- a/src/data_index/transform.py
+++ b/src/data_index/transform.py
@@ -12,10 +12,10 @@ import prefect.cache_policies
 from data_index.protocols import (
     ExtractionResult,
     MetadataExtractor,
-    StructuredMetadata,
     UnstructuredMetadata,
     XarrayHandle,
 )
+from data_index.structured_metadata import StructuredMetadata
 from data_index.unstructured_metadata import DiskCachedUnstructuredMetadata
 
 
@@ -134,7 +134,7 @@ def transform(
     _SAMPLE = 5
     sample_df = (
         polars.DataFrame(
-            [vars(s) for s in structured[:_SAMPLE]],
+            data=[vars(s) for s in structured[:_SAMPLE]],
             schema=StructuredMetadata.polars_schema,
         )
         if structured

--- a/src/data_index/transform.py
+++ b/src/data_index/transform.py
@@ -132,13 +132,14 @@ def transform(
     ]
 
     _SAMPLE = 5
+    schema = StructuredMetadata.as_polars_schema()
     sample_df = (
         polars.DataFrame(
             data=[vars(s) for s in structured[:_SAMPLE]],
-            schema=StructuredMetadata.polars_schema,
+            schema=schema,
         )
         if structured
-        else polars.DataFrame(schema=StructuredMetadata.polars_schema)
+        else polars.DataFrame(schema=schema)
     )
     prefect.artifacts.create_table_artifact(
         key="structured-metadata-sample",

--- a/src/data_index/unstructured_sink/parquet_sink.py
+++ b/src/data_index/unstructured_sink/parquet_sink.py
@@ -27,4 +27,9 @@ class ParquetSink:
             else polars.DataFrame(schema=schema)
         )
         self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.exists():
+            if not rows:
+                return
+            existing_df = polars.read_parquet(self.path)
+            df = polars.concat([existing_df, df], how="vertical")
         df.write_parquet(self.path)

--- a/tests/test_attribute_netcdf_extractor.py
+++ b/tests/test_attribute_netcdf_extractor.py
@@ -1,0 +1,113 @@
+import xarray
+
+from data_index.metadata_extractor.attribute_netcdf_extractor import (
+    AttributeNetCDFExtractor,
+)
+
+
+class StubHandle:
+    def __init__(
+        self,
+        ds: xarray.Dataset,
+        s3_uri: str = "s3://imos-data/IMOS/ANMN/NSW/file.nc",
+        file_format: str | None = None,
+    ):
+        self._ds = ds
+        self.s3_uri = s3_uri
+        self.file_format = file_format
+
+    @property
+    def ds(self) -> xarray.Dataset:
+        return self._ds
+
+    def cleanup(self) -> None:
+        pass
+
+
+def test_extract_supports_aliases_for_structured_scalar_attributes():
+    extractor = AttributeNetCDFExtractor()
+    ds = xarray.Dataset(
+        attrs={
+            "conventions": "CF-1.8",
+            "featureType": "trajectory",
+            "instrumentSerialNumber": "INS-001",
+        }
+    )
+
+    result = extractor.extract(StubHandle(ds))
+
+    assert result.status == "succeeded"
+    assert result.structured_metadata is not None
+    assert result.structured_metadata.conventions == "CF-1.8"
+    assert result.structured_metadata.feature_type == "trajectory"
+    assert result.structured_metadata.instrument_serial_number == "INS-001"
+
+
+def test_extract_prioritizes_exact_alias_order_over_normalized_fallback():
+    extractor = AttributeNetCDFExtractor()
+    ds = xarray.Dataset(
+        attrs={
+            "Conventions": "CF-UPPER",
+            "conventions": "CF-lower",
+            "instrument-serial-number": "INS-fallback",
+        }
+    )
+
+    result = extractor.extract(StubHandle(ds))
+
+    assert result.status == "succeeded"
+    assert result.structured_metadata is not None
+    assert result.structured_metadata.conventions == "CF-UPPER"
+    assert result.structured_metadata.instrument_serial_number == "INS-fallback"
+
+
+def test_extract_derives_dimensions_variables_and_standard_names():
+    extractor = AttributeNetCDFExtractor()
+    ds = xarray.Dataset(
+        data_vars={
+            "temp": xarray.DataArray(
+                [[1.0, 2.0]],
+                dims=("time", "lat"),
+                attrs={"standard_name": "sea_water_temperature"},
+            ),
+            "salinity": xarray.DataArray(
+                [[35.0, 35.1]],
+                dims=("time", "lat"),
+                attrs={"standard_name": "sea_water_salinity"},
+            ),
+        },
+        coords={
+            "time": xarray.DataArray(
+                [0], dims=("time",), attrs={"standard_name": "time"}
+            ),
+            "lat": xarray.DataArray(
+                [10.0, 11.0], dims=("lat",), attrs={"standard_name": "latitude"}
+            ),
+        },
+    )
+
+    result = extractor.extract(StubHandle(ds))
+
+    assert result.status == "succeeded"
+    assert result.structured_metadata is not None
+    assert result.structured_metadata.dimensions == ["lat", "time"]
+    assert result.structured_metadata.variables == ["salinity", "temp"]
+    assert result.structured_metadata.standard_names == [
+        "latitude",
+        "sea_water_salinity",
+        "sea_water_temperature",
+        "time",
+    ]
+
+
+def test_extract_sets_derived_lists_to_none_when_empty():
+    extractor = AttributeNetCDFExtractor()
+    ds = xarray.Dataset()
+
+    result = extractor.extract(StubHandle(ds))
+
+    assert result.status == "succeeded"
+    assert result.structured_metadata is not None
+    assert result.structured_metadata.dimensions is None
+    assert result.structured_metadata.variables is None
+    assert result.structured_metadata.standard_names is None

--- a/tests/test_attribute_netcdf_extractor.py
+++ b/tests/test_attribute_netcdf_extractor.py
@@ -111,3 +111,14 @@ def test_extract_sets_derived_lists_to_none_when_empty():
     assert result.structured_metadata.dimensions is None
     assert result.structured_metadata.variables is None
     assert result.structured_metadata.standard_names is None
+
+
+def test_extract_succeeds_with_surrogate_string_in_global_attrs():
+    extractor = AttributeNetCDFExtractor()
+    ds = xarray.Dataset(attrs={"title": f"{chr(0xDCFF)}bad"})
+
+    result = extractor.extract(StubHandle(ds))
+
+    assert result.status == "succeeded"
+    assert result.unstructured_metadata is not None
+    assert result.unstructured_metadata["global_attrs"]["title"] == "\\udcffbad"

--- a/tests/test_live_s3_facility_subset_inventory_source.py
+++ b/tests/test_live_s3_facility_subset_inventory_source.py
@@ -1,0 +1,67 @@
+import pathlib
+
+import polars
+
+from data_index.inventory_source.live_s3_facility_subset import (
+    LiveS3InventorySourceFacilitySubset,
+)
+
+
+def _write_inventory(path: pathlib.Path, rows: list[dict]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    polars.DataFrame(rows).write_parquet(path / "part-0.parquet")
+
+
+def test_inventory_subsets_per_facility(tmp_path: pathlib.Path):
+    path = tmp_path / "s3_metadata"
+    _write_inventory(
+        path,
+        [
+            {"bucket": "imos-data", "key": "IMOS/ACORN/a1.nc", "size": 1},
+            {"bucket": "imos-data", "key": "IMOS/ACORN/a2.nc", "size": 2},
+            {"bucket": "imos-data", "key": "IMOS/ACORN/a3.nc", "size": 3},
+            {"bucket": "imos-data", "key": "IMOS/ANMN/b1.nc", "size": 4},
+            {"bucket": "imos-data", "key": "IMOS/ANMN/b2.nc", "size": 5},
+            {"bucket": "imos-data", "key": "IMOS/ANMN/b3.nc", "size": 6},
+            {"bucket": "imos-data", "key": "misc/other.nc", "size": 7},
+        ],
+    )
+
+    source = LiveS3InventorySourceFacilitySubset.model_construct(
+        table_config=None,
+        table_scan_config=None,
+        path=path,
+        skip_if_exists=True,
+        subset_per_facility=2,
+    )
+
+    df = source.inventory()
+
+    assert set(df.columns) == {"s3_uri", "size"}
+    assert len(df.filter(polars.col("s3_uri").str.contains("/IMOS/ACORN/"))) == 2
+    assert len(df.filter(polars.col("s3_uri").str.contains("/IMOS/ANMN/"))) == 2
+    assert not df["s3_uri"].str.contains("/misc/").any()
+
+
+def test_inventory_subset_excludes_non_facility_paths(tmp_path: pathlib.Path):
+    path = tmp_path / "s3_metadata"
+    _write_inventory(
+        path,
+        [
+            {"bucket": "imos-data", "key": "IMOS/ACORN/a1.nc", "size": 1},
+            {"bucket": "imos-data", "key": "misc/other.nc", "size": 2},
+        ],
+    )
+
+    source = LiveS3InventorySourceFacilitySubset.model_construct(
+        table_config=None,
+        table_scan_config=None,
+        path=path,
+        skip_if_exists=True,
+        subset_per_facility=1,
+    )
+
+    df = source.inventory()
+
+    assert len(df) == 1
+    assert df["s3_uri"].to_list() == ["s3://imos-data/IMOS/ACORN/a1.nc"]

--- a/tests/test_netcdf_extractor.py
+++ b/tests/test_netcdf_extractor.py
@@ -190,6 +190,18 @@ def test_unstructured_metadata_with_numpy_bool_attribute_is_json_serialisable(
     assert data["global_attrs"]["is_calibrated"] is True
 
 
+def test_unstructured_metadata_with_surrogate_string_attribute_is_sanitized(extractor):
+    ds = make_dataset(
+        lat=[-5.0, 5.0],
+        global_attrs={"title": f"{chr(0xDCFF)}bad"},
+    )
+    result = extractor.extract(StubHandle(ds, s3_uri="s3://bucket/file.nc"))
+
+    assert result.status == "succeeded"
+    assert result.unstructured_metadata["global_attrs"]["title"] == "\\udcffbad"
+    json.dumps(result.unstructured_metadata)
+
+
 def test_extracts_collection_as_second_path_segment(extractor):
     ds = xarray.Dataset()
     result = extractor.extract(

--- a/tests/test_structured_metadata.py
+++ b/tests/test_structured_metadata.py
@@ -76,3 +76,10 @@ def test_structured_metadata_field_contract_updates():
     assert "dimensions" in field_names
     assert "variables" in field_names
     assert "standard_names" in field_names
+
+
+def test_schema_version_is_class_var_and_not_dataclass_field():
+    field_names = [field.name for field in dataclasses.fields(StructuredMetadata)]
+
+    assert StructuredMetadata.SCHEMA_VERSION == 1
+    assert "SCHEMA_VERSION" not in field_names

--- a/tests/test_structured_metadata.py
+++ b/tests/test_structured_metadata.py
@@ -1,0 +1,24 @@
+import dataclasses
+
+import polars
+import pyarrow
+
+from data_index.structured_metadata import StructuredMetadata
+
+
+def test_as_polars_schema_maps_required_and_optional_types():
+    schema = StructuredMetadata.as_polars_schema()
+
+    assert schema["s3_uri"] == polars.String
+    assert schema["lat_min"] == polars.Float64
+    assert schema["time_min"] == polars.String
+    assert len(schema) == len(dataclasses.fields(StructuredMetadata))
+
+
+def test_as_pyarrow_schema_preserves_nullable_fields():
+    schema = StructuredMetadata.as_pyarrow_schema()
+
+    assert schema.field("s3_uri").type == pyarrow.string()
+    assert schema.field("s3_uri").nullable is False
+    assert schema.field("lat_min").type == pyarrow.float64()
+    assert schema.field("lat_min").nullable is True

--- a/tests/test_structured_metadata.py
+++ b/tests/test_structured_metadata.py
@@ -2,9 +2,14 @@ import dataclasses
 
 import polars
 import pyarrow
-from pyiceberg.types import DoubleType, StringType
+from pyiceberg.types import DoubleType, ListType, StringType
 
 from data_index.structured_metadata import StructuredMetadata
+
+
+@dataclasses.dataclass
+class StructuredMetadataWithList(StructuredMetadata):
+    tags: list[str] | None = None
 
 
 def test_as_polars_schema_maps_required_and_optional_types():
@@ -33,3 +38,26 @@ def test_as_pyiceberg_schema_preserves_nullable_fields():
     assert schema.find_field("lat_min").field_type == DoubleType()
     assert schema.find_field("lat_min").required is False
     assert len(schema.fields) == len(dataclasses.fields(StructuredMetadata))
+
+
+def test_as_polars_schema_maps_optional_list_string():
+    schema = StructuredMetadataWithList.as_polars_schema()
+
+    assert schema["tags"] == polars.List(polars.String)
+
+
+def test_as_pyarrow_schema_maps_optional_list_string():
+    schema = StructuredMetadataWithList.as_pyarrow_schema()
+
+    assert schema.field("tags").type == pyarrow.list_(pyarrow.string())
+    assert schema.field("tags").nullable is True
+
+
+def test_as_pyiceberg_schema_maps_optional_list_string():
+    schema = StructuredMetadataWithList.as_pyiceberg_schema()
+    tags_field_type = schema.find_field("tags").field_type
+
+    assert isinstance(tags_field_type, ListType)
+    assert tags_field_type.element_type == StringType()
+    assert tags_field_type.element_id > 0
+    assert schema.find_field("tags").required is False

--- a/tests/test_structured_metadata.py
+++ b/tests/test_structured_metadata.py
@@ -2,6 +2,7 @@ import dataclasses
 
 import polars
 import pyarrow
+from pyiceberg.types import DoubleType, StringType
 
 from data_index.structured_metadata import StructuredMetadata
 
@@ -22,3 +23,13 @@ def test_as_pyarrow_schema_preserves_nullable_fields():
     assert schema.field("s3_uri").nullable is False
     assert schema.field("lat_min").type == pyarrow.float64()
     assert schema.field("lat_min").nullable is True
+
+
+def test_as_pyiceberg_schema_preserves_nullable_fields():
+    schema = StructuredMetadata.as_pyiceberg_schema()
+
+    assert schema.find_field("s3_uri").field_type == StringType()
+    assert schema.find_field("s3_uri").required is True
+    assert schema.find_field("lat_min").field_type == DoubleType()
+    assert schema.find_field("lat_min").required is False
+    assert len(schema.fields) == len(dataclasses.fields(StructuredMetadata))

--- a/tests/test_structured_metadata.py
+++ b/tests/test_structured_metadata.py
@@ -48,8 +48,12 @@ def test_as_polars_schema_maps_optional_list_string():
 
 def test_as_pyarrow_schema_maps_optional_list_string():
     schema = StructuredMetadataWithList.as_pyarrow_schema()
+    tags_type = schema.field("tags").type
 
-    assert schema.field("tags").type == pyarrow.list_(pyarrow.string())
+    assert tags_type == pyarrow.list_(
+        pyarrow.field("item", pyarrow.string(), nullable=False)
+    )
+    assert tags_type.value_field.nullable is False
     assert schema.field("tags").nullable is True
 
 
@@ -61,3 +65,14 @@ def test_as_pyiceberg_schema_maps_optional_list_string():
     assert tags_field_type.element_type == StringType()
     assert tags_field_type.element_id > 0
     assert schema.find_field("tags").required is False
+
+
+def test_structured_metadata_field_contract_updates():
+    field_names = [field.name for field in dataclasses.fields(StructuredMetadata)]
+
+    assert "file_version_quality_control" not in field_names
+    assert "feature_type" in field_names
+    assert "instrument_serial_number" in field_names
+    assert "dimensions" in field_names
+    assert "variables" in field_names
+    assert "standard_names" in field_names

--- a/tests/test_structured_parquet_sink.py
+++ b/tests/test_structured_parquet_sink.py
@@ -76,3 +76,15 @@ def test_writes_none_fields_as_null(tmp_path):
     df = polars.read_parquet(path)
     assert df["lat_min"][0] is None
     assert df["crs"][0] is None
+
+
+def test_appends_on_subsequent_writes(tmp_path):
+    path = tmp_path / "out.parquet"
+    sink = ParquetSink(path=path)
+
+    sink.write([make_metadata(s3_uri="s3://bucket/a.nc", lat_min=-1.0)])
+    sink.write([make_metadata(s3_uri="s3://bucket/b.nc", lat_min=-2.0)])
+
+    df = polars.read_parquet(path)
+    assert len(df) == 2
+    assert set(df["s3_uri"].to_list()) == {"s3://bucket/a.nc", "s3://bucket/b.nc"}

--- a/tests/test_structured_parquet_sink.py
+++ b/tests/test_structured_parquet_sink.py
@@ -1,7 +1,7 @@
 import polars
 import pytest
 
-from data_index.protocols import StructuredMetadata
+from data_index.structured_metadata import StructuredMetadata
 from data_index.structured_sink.parquet_sink import ParquetSink
 
 
@@ -41,7 +41,7 @@ def test_writes_rows_with_correct_schema_and_values(tmp_path):
     sink.write(rows)
 
     df = polars.read_parquet(path)
-    assert df.schema == StructuredMetadata.polars_schema
+    assert df.schema == StructuredMetadata.as_polars_schema()
     assert len(df) == 2
     assert df["s3_uri"].to_list() == ["s3://bucket/a.nc", "s3://bucket/b.nc"]
     assert df["lat_min"].to_list() == pytest.approx([-1.0, -2.0])
@@ -54,7 +54,7 @@ def test_writes_empty_parquet_with_correct_schema_for_empty_input(tmp_path):
     sink.write([])
 
     df = polars.read_parquet(path)
-    assert df.schema == StructuredMetadata.polars_schema
+    assert df.schema == StructuredMetadata.as_polars_schema()
     assert len(df) == 0
 
 

--- a/tests/test_structured_s3_table_sink.py
+++ b/tests/test_structured_s3_table_sink.py
@@ -1,7 +1,11 @@
+import dataclasses
+
 import pytest
+from pyiceberg.schema import Schema
+from pyiceberg.types import DoubleType, NestedField, StringType
 
 from data_index.iceberg_config import IcebergTableConfig, SqliteCatalogConfig
-from data_index.protocols import StructuredMetadata
+from data_index.structured_metadata import StructuredMetadata
 from data_index.structured_sink.s3_table_sink import StructuredS3TableSink
 
 NAMESPACE = "test_ns"
@@ -91,3 +95,78 @@ def test_null_fields_survive_roundtrip(table_config):
     assert df["lat_min"].isna().all()
     assert df["crs"].isna().all()
     assert df["collection"].isna().all()
+
+
+def test_writes_extended_structured_metadata_fields(table_config):
+    sink = StructuredS3TableSink(iceberg_table_config=table_config)
+
+    sink.write(
+        [
+            make_metadata(
+                keywords="ocean,temp",
+                instrument="CTD",
+                metadata_uuid="123e4567-e89b-12d3-a456-426614174000",
+            )
+        ]
+    )
+
+    df = table_config.load().scan().to_pandas()
+    assert df["keywords"].iloc[0] == "ocean,temp"
+    assert df["instrument"].iloc[0] == "CTD"
+    assert df["metadata_uuid"].iloc[0] == "123e4567-e89b-12d3-a456-426614174000"
+
+
+def test_provision_evolves_existing_legacy_schema(tmp_path):
+    config = IcebergTableConfig(
+        catalog_config=SqliteCatalogConfig(
+            uri=f"sqlite:///{tmp_path}/catalog.db",
+            warehouse=str(tmp_path / "warehouse"),
+        ),
+        namespace=NAMESPACE,
+        table_name=TABLE_NAME,
+    )
+    sink = StructuredS3TableSink(iceberg_table_config=config)
+
+    sink.catalog.create_namespace(config.namespace)
+    sink.catalog.create_table(
+        identifier=(config.namespace, config.table_name),
+        schema=Schema(
+            NestedField(
+                field_id=1, name="s3_uri", field_type=StringType(), required=True
+            ),
+            NestedField(
+                field_id=2, name="lat_min", field_type=DoubleType(), required=False
+            ),
+            NestedField(
+                field_id=3, name="lat_max", field_type=DoubleType(), required=False
+            ),
+            NestedField(
+                field_id=4, name="lon_min", field_type=DoubleType(), required=False
+            ),
+            NestedField(
+                field_id=5, name="lon_max", field_type=DoubleType(), required=False
+            ),
+            NestedField(
+                field_id=6, name="time_min", field_type=StringType(), required=False
+            ),
+            NestedField(
+                field_id=7, name="time_max", field_type=StringType(), required=False
+            ),
+            NestedField(
+                field_id=8, name="crs", field_type=StringType(), required=False
+            ),
+            NestedField(
+                field_id=9, name="file_format", field_type=StringType(), required=False
+            ),
+            NestedField(
+                field_id=10, name="collection", field_type=StringType(), required=False
+            ),
+        ),
+    )
+
+    sink.provision()
+
+    schema = config.load().schema()
+    assert schema.find_field("keywords").required is False
+    assert schema.find_field("instrument").required is False
+    assert len(schema.fields) == len(dataclasses.fields(StructuredMetadata))

--- a/tests/test_unstructured_parquet_sink.py
+++ b/tests/test_unstructured_parquet_sink.py
@@ -50,3 +50,15 @@ def test_creates_parent_directories_if_needed(tmp_path):
     sink.write({"s3://bucket/x.nc": {"key": "value"}})
 
     assert path.exists()
+
+
+def test_appends_on_subsequent_writes(tmp_path):
+    path = tmp_path / "out.parquet"
+    sink = ParquetSink(path=path)
+
+    sink.write({"s3://bucket/a.nc": {"title": "A"}})
+    sink.write({"s3://bucket/b.nc": {"title": "B"}})
+
+    df = polars.read_parquet(path)
+    assert len(df) == 2
+    assert set(df["s3_uri"].to_list()) == {"s3://bucket/a.nc", "s3://bucket/b.nc"}

--- a/uv.lock
+++ b/uv.lock
@@ -675,8 +675,10 @@ dependencies = [
 [package.dev-dependencies]
 analysis = [
     { name = "altair" },
+    { name = "genson" },
     { name = "ipykernel" },
     { name = "jupyterlab" },
+    { name = "natsort" },
     { name = "rich" },
 ]
 dev = [
@@ -714,8 +716,10 @@ requires-dist = [
 [package.metadata.requires-dev]
 analysis = [
     { name = "altair", specifier = ">=5" },
+    { name = "genson", specifier = ">=1.3.0" },
     { name = "ipykernel", specifier = ">=6" },
     { name = "jupyterlab", specifier = ">=4" },
+    { name = "natsort", specifier = ">=8.4.0" },
     { name = "rich", specifier = ">=13" },
 ]
 dev = [
@@ -944,6 +948,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "genson"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload-time = "2024-05-15T22:08:49.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload-time = "2024-05-15T22:08:47.056Z" },
 ]
 
 [[package]]
@@ -1675,6 +1688,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/a0/6198c56d42ef2f3c6ed0c42ba30dbcefdc86a91262d7d449010770ae085b/narwhals-2.21.2.tar.gz", hash = "sha256:5c5b2d0b47aef7c73ea412cfcbcd467f2f2d5be73e3c2ab19d78f4a97718790a", size = 632176, upload-time = "2026-05-16T08:49:08.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/77/928ea2e70641ca177a11140062cc5840d421795f2e82749d408d0cce900a/narwhals-2.21.2-py3-none-any.whl", hash = "sha256:7bb57c3700486039215455b9bf2d64261915cc0fd845cc30272d631df696b251", size = 451201, upload-time = "2026-05-16T08:49:05.536Z" },
+]
+
+[[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces several important improvements and clarifications to the local subset metadata analysis workflow, S3 table configuration, and domain terminology. The main themes are: (1) clarifying the canonical use of "Facility" vs "collection" in domain language and code, (2) adding new local subset and analysis handoff documentation, (3) updating configuration and defaults for local and subset indexing, and (4) providing new developer documentation for S3 table management.

**Domain terminology and schema clarifications:**

- Updated `CONTEXT.md` to clarify that "Facility" is now the canonical term for the second S3 path segment (e.g., `IMOS/ANMN/NSW/file.nc`), while `collection` is retained only as a legacy field/schema name for backward compatibility. All relevant glossary, ambiguity, and schema sections were updated to reflect this, and ambiguity between "collection" and "facility" is now explicitly resolved. [[1]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R15-R20) [[2]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14L77-R85) [[3]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R95) [[4]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R127)

**Local subset pipeline and configuration:**

- Added a new module `local_subset.py` that defines a local subset pipeline using `LiveS3InventorySourceFacilitySubset`, with explicit configuration for inventory, sinks, and a threshold-based fetcher. This enables targeted facility-based sampling for local analysis.
- Refactored `local.py` to use the canonical `AttributeNetCDFExtractor` by default, updated variable names for clarity, and tuned worker/thread settings for local runs. [[1]](diffhunk://#diff-ece6a9aefaeeb104b0b4e9eecbfb3d9b7a27827e64bb5c7e72b4b6f9211f93c8L14-R18) [[2]](diffhunk://#diff-ece6a9aefaeeb104b0b4e9eecbfb3d9b7a27827e64bb5c7e72b4b6f9211f93c8L32-R115)

**Analysis and handoff documentation:**

- Added two new handoff documents:
  - [`2026-06-02-local-subset-metadata-analysis.md`](diffhunk://#diff-0ad02a55ec694d7604b62f3c33b349c9db7692f102f95250b06892374f9af88fR1-R74): Outlines the analysis design, metrics, glossary decisions, and concrete next steps for evaluating facility extraction, structured field coverage, and unstructured mapping correctness.
  - [`2026-06-02-structured-metadata-schema-feedback.md`](diffhunk://#diff-de6599022d5a9d96041c6f45f512bd96180eff175c461f239b65c27742599b01R1-R64): Documents stakeholder feedback and decisions for upcoming schema changes, including new fields, alias handling, and test requirements.

**Developer documentation and analysis support:**

- Added a new section to `managing-s3-tables.md` documenting how to delete S3 tables and table buckets using the AWS CLI, supporting easier management of Iceberg tables.
- Added a new analysis notebook (`analysis/structured_metadata/v1.ipynb`) to demonstrate configuration and usage of Iceberg table configs for structured and unstructured metadata.
- Added new analysis dependencies (`genson`, `natsort`) to `pyproject.toml` to support schema generation and sorting in analysis scripts.

**Summary of most important changes:**

**1. Domain terminology and schema updates**
- Clarified "Facility" as the canonical term for the second S3 path segment in all documentation and code references; "collection" is now only a legacy field/schema name. [[1]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R15-R20) [[2]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14L77-R85) [[3]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R95) [[4]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R127)

**2. Local subset pipeline and configuration**
- Added `local_subset.py` for facility-based local subset indexing, with explicit configuration for inventory, sinks, and fetcher.
- Refactored `local.py` to default to `AttributeNetCDFExtractor`, improved naming, and tuned worker/thread settings for local development. [[1]](diffhunk://#diff-ece6a9aefaeeb104b0b4e9eecbfb3d9b7a27827e64bb5c7e72b4b6f9211f93c8L14-R18) [[2]](diffhunk://#diff-ece6a9aefaeeb104b0b4e9eecbfb3d9b7a27827e64bb5c7e72b4b6f9211f93c8L32-R115)

**3. Analysis and handoff documentation**
- Added handoff docs for local subset analysis and structured metadata schema feedback, capturing decisions, metrics, and next steps for analysis and schema evolution. [[1]](diffhunk://#diff-0ad02a55ec694d7604b62f3c33b349c9db7692f102f95250b06892374f9af88fR1-R74) [[2]](diffhunk://#diff-de6599022d5a9d96041c6f45f512bd96180eff175c461f239b65c27742599b01R1-R64)

**4. Developer and analysis support**
- Added documentation for deleting S3 tables and table buckets with AWS CLI.
- Introduced a new analysis notebook and updated analysis dependencies for schema and sorting support. [[1]](diffhunk://#diff-d51404df925446d854ebe9cb855d86a39a661254968e6d321f8e4a3b3198ba98R1-R71) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R67-R70)